### PR TITLE
phpstan no longer output errors

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -196,7 +196,7 @@ trait InteractsWithIO
         );
     }
 
-    protected function forceOrConfirm(string $confirmation, ?bool $default = true): bool
+    protected function forceOrConfirm(string $confirmation, bool $default = true): bool
     {
         return (bool) $this->option('force') || $this->confirm($confirmation, $default);
     }

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -213,7 +213,7 @@ trait InteractsWithIO
 
         $resources->each(function ($resource) use ($resources, $endpoint, &$events, $verb) {
             try {
-                $eventId = $resource->$endpoint();
+                $eventId = call_user_func(fn () => $resource->$endpoint());
                 $events[] = ["{$eventId}", $resource->name];
             } catch (\Exception $e) {
                 if ($resources->count() === 1) {

--- a/app/Commands/Servers/DeleteCommand.php
+++ b/app/Commands/Servers/DeleteCommand.php
@@ -3,9 +3,12 @@
 namespace App\Commands\Servers;
 
 use App\Commands\BaseCommand;
+use App\Commands\Concerns\SelectsServer;
 
 class DeleteCommand extends BaseCommand
 {
+    use SelectsServer;
+
     protected $signature = 'servers:delete
                             {server_id? : The server to delete}
                             {--d|delete-on-provider : Delete the server from the server provider (DigitalOcean, etc.)}

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -13,7 +13,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
 
     protected function action(): int
     {
-        $cacheToPurge = strval($this->argument('cache'));
+        $cacheToPurge = strval($this->option('cache'));
 
         if (empty($cacheToPurge)) {
             $cacheToPurge = (int) $this->askToSelect('Which cache do you want to purge', [

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -44,12 +44,12 @@ class PurgeCommand extends \App\Commands\BaseCommand
 
     protected function purgeCacheOnAllSites(string $cacheToPurge): void
     {
-        $sites      = $this->spinupwp->sites->list();
+        $sites      = $this->spinupwp->sites->list()->toArray();
         $shouldWait = count($sites) > 59;
         $this->purgeCache($sites, $cacheToPurge, $shouldWait);
     }
 
-    protected function purgeCache($sites, string $cacheToPurge, $shouldWait = false): void
+    protected function purgeCache(array $sites, string $cacheToPurge, bool $shouldWait = false): void
     {
         if (empty($sites)) {
             return;

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -13,7 +13,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
 
     protected function action(): int
     {
-        $cacheToPurge = $this->option('cache');
+        $cacheToPurge = strval($this->argument('cache'));
 
         if (empty($cacheToPurge)) {
             $cacheToPurge = (int) $this->askToSelect('Which cache do you want to purge', [
@@ -35,7 +35,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
             $siteId = $this->askToSelectSite('Which site do you want to purge the page cache for');
         }
 
-        $site = $this->spinupwp->sites->get($siteId);
+        $site = $this->spinupwp->sites->get(intval($siteId));
 
         $this->purgeCache([$site], $cacheToPurge);
 


### PR DESCRIPTION
Resolves #30 

## Description
Fixed some type hints and other issues and added a missing trait that was causing the `servers:delete ` command to fail.

## Visuals
N/A

## Testing Instructions
1. Run composer phpstan
2. Run php spinupwp servers:delete

## Related Documentation
N/A

## Pre-review Checklist
- [x] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Feature/Unit tests have been added and/or updated (where appropriate).
- [x] Self-review of code changes has been completed.
- [N/A] Self-review of UI and UX changes has been completed, including dark mode and mobile responsiveness.
    - [N/A] UI matches the provided Figma mockups (when available).
- [x] Modified and surrounding functionality has been tested. Considerations have been made for both new and existing servers and sites.