### PR TITLE
Purge site command output is now consistent with other commands

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -205,7 +205,7 @@ trait InteractsWithIO
         return (bool) $this->option('force') || $this->confirm($confirmation, $default);
     }
 
-    public function queueResources(Collection $resources, string $endpoint, string $verb, string $resourcesId = 'name'): void
+    public function queueResources(Collection $resources, string $endpoint, string $verb, string $resourcesId = 'name', bool $shouldWait = false): void
     {
         if ($resources->isEmpty()) {
             return;
@@ -215,12 +215,14 @@ trait InteractsWithIO
 
         $events = [];
 
-        $resources->each(function ($resource) use ($resources, $endpoint, &$events, $verb, $resourcesId) {
+        $resources->each(function ($resource) use ($resources, $endpoint, &$events, $verb, $resourcesId, $shouldWait) {
             try {
+                if ($shouldWait) {
+                    sleep(1);
+                }
                 $eventId = call_user_func(fn () => $resource->$endpoint());
                 $events[] = ["{$eventId}", $resource->{$resourcesId}];
             } catch (\Exception $e) {
-                dd($e);
                 if ($resources->count() === 1) {
                     $this->error("{$verb} failed on {$resource->name}.");
                 }

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -115,6 +115,10 @@ trait InteractsWithIO
             $choices = $choices->filter(fn ($site) => $filter($site));
         }
 
+        if ($choices->isEmpty()) {
+            return 0;
+        }
+
         return $this->askToSelect(
             $question,
             $choices->keyBy('id')->map(fn ($site) => $site->domain)->toArray()
@@ -201,21 +205,22 @@ trait InteractsWithIO
         return (bool) $this->option('force') || $this->confirm($confirmation, $default);
     }
 
-    public function queueResources(Collection $resources, string $endpoint, string $verb): void
+    public function queueResources(Collection $resources, string $endpoint, string $verb, string $resourcesId = 'name'): void
     {
         if ($resources->isEmpty()) {
             return;
         }
 
-        $resourceName = strtolower(class_basename($resources[0]));
+        $resourceName = strtolower(class_basename($resources->first()));
 
         $events = [];
 
-        $resources->each(function ($resource) use ($resources, $endpoint, &$events, $verb) {
+        $resources->each(function ($resource) use ($resources, $endpoint, &$events, $verb, $resourcesId) {
             try {
                 $eventId = call_user_func(fn () => $resource->$endpoint());
-                $events[] = ["{$eventId}", $resource->name];
+                $events[] = ["{$eventId}", $resource->{$resourcesId}];
             } catch (\Exception $e) {
+                dd($e);
                 if ($resources->count() === 1) {
                     $this->error("{$verb} failed on {$resource->name}.");
                 }

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -76,7 +76,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
 
     protected function purgeCache(Collection $sites, string $cacheToPurge, bool $shouldWait = false): void
     {
-        if (empty($sites)) {
+        if ($sites->isEmpty()) {
             return;
         }
 

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -43,7 +43,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
         }
 
         if ($siteId === 0) {
-            $this->warn("There are no sites with {$cacheToPurge} cache enabled");
+            $this->warn("There are no sites with {$cacheToPurge} cache enabled.");
             return self::SUCCESS;
         }
 
@@ -65,7 +65,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
         }
 
         if ($sites->isEmpty()) {
-            $this->warn("There are no sites with {$cacheToPurge} cache enabled");
+            $this->warn("There are no sites with {$cacheToPurge} cache enabled.");
             return;
         }
 
@@ -81,7 +81,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
         }
 
         $endpoint = $cacheToPurge === 'page' ? 'purgePageCache' : 'purgeObjectCache';
-        $verb     = "purging {$cacheToPurge} cache";
+        $verb     = "{$cacheToPurge} cache purge";
         $this->queueResources($sites, $endpoint, $verb, 'domain', $shouldWait);
     }
 }

--- a/app/Commands/Sites/PurgeCommand.php
+++ b/app/Commands/Sites/PurgeCommand.php
@@ -69,7 +69,7 @@ class PurgeCommand extends \App\Commands\BaseCommand
             return;
         }
 
-        $shouldWait = $sites->count() > 59;
+        $shouldWait = $sites->count() > 55;
 
         $this->purgeCache($sites, $cacheToPurge, $shouldWait);
     }
@@ -82,6 +82,6 @@ class PurgeCommand extends \App\Commands\BaseCommand
 
         $endpoint = $cacheToPurge === 'page' ? 'purgePageCache' : 'purgeObjectCache';
         $verb     = "purging {$cacheToPurge} cache";
-        $this->queueResources($sites, $endpoint, $verb, 'domain');
+        $this->queueResources($sites, $endpoint, $verb, 'domain', $shouldWait);
     }
 }

--- a/tests/Feature/Commands/SitesPurgeCommandTest.php
+++ b/tests/Feature/Commands/SitesPurgeCommandTest.php
@@ -30,11 +30,11 @@ afterEach(function () {
 });
 
 test('purge site page cache', function () {
-    $this->artisan('sites:purge 1 --cache=page')->expectsOutput('==> Site queued for purging page cache.');
+    $this->artisan('sites:purge 1 --cache=page')->expectsOutput('==> Site queued for page cache purge.');
 });
 
 test('purge site object cache', function () {
-    $this->artisan('sites:purge 1 --cache=object')->expectsOutput('==> Site queued for purging object cache.');
+    $this->artisan('sites:purge 1 --cache=object')->expectsOutput('==> Site queued for object cache purge.');
 });
 
 test('purge all sites page cache', function () {
@@ -50,7 +50,7 @@ test('purge all sites page cache', function () {
         ->andReturn(new Response(200, [], json_encode(['event_id' => 101])));
 
     $this->artisan('sites:purge --all --cache=page')
-    ->expectsOutput('==> Sites queued for purging page cache.');
+    ->expectsOutput('==> Sites queued for page cache purge.');
 });
 
 test('purge all sites object cache', function () {
@@ -66,5 +66,5 @@ test('purge all sites object cache', function () {
         ->andReturn(new Response(200, [], json_encode(['event_id' => 101])));
 
     $this->artisan('sites:purge --all --cache=object')
-        ->expectsOutput('==> Sites queued for purging object cache.');
+        ->expectsOutput('==> Sites queued for object cache purge.');
 });

--- a/tests/Feature/Commands/SitesPurgeCommandTest.php
+++ b/tests/Feature/Commands/SitesPurgeCommandTest.php
@@ -12,6 +12,7 @@ beforeEach(function () {
             'page_cache' => [
                 'enabled' => true,
             ],
+            'is_wordpress' => true,
         ]]))
     );
 
@@ -29,18 +30,18 @@ afterEach(function () {
 });
 
 test('purge site page cache', function () {
-    $this->artisan('sites:purge 1 --cache=page')->expectsOutput('Purging page cache for site hellfish.media. Event ID: 100');
+    $this->artisan('sites:purge 1 --cache=page')->expectsOutput('==> Site queued for purging page cache.');
 });
 
 test('purge site object cache', function () {
-    $this->artisan('sites:purge 1 --cache=object')->expectsOutput('Purging object cache for site hellfish.media. Event ID: 100');
+    $this->artisan('sites:purge 1 --cache=object')->expectsOutput('==> Site queued for purging object cache.');
 });
 
 test('purge all sites page cache', function () {
     $this->clientMock->shouldReceive('request')->once()->with('GET', 'sites?page=1', [])->andReturn(
         new Response(200, [], listResponseJson([
-            ['id' => 1, 'domain' => 'hellfish.media', 'page_cache' => ['enabled' => true]],
-            ['id' => 2, 'domain' => 'staging.hellfish.media', 'page_cache' => ['enabled' => true]],
+            ['id' => 1, 'domain' => 'hellfish.media', 'page_cache' => ['enabled' => true], 'is_wordpress' => true],
+            ['id' => 2, 'domain' => 'staging.hellfish.media', 'page_cache' => ['enabled' => true], 'is_wordpress' => true],
         ]))
     );
 
@@ -49,15 +50,14 @@ test('purge all sites page cache', function () {
         ->andReturn(new Response(200, [], json_encode(['event_id' => 101])));
 
     $this->artisan('sites:purge --all --cache=page')
-        ->expectsOutput('Purging page cache for site hellfish.media. Event ID: 100')
-        ->expectsOutput('Purging page cache for site staging.hellfish.media. Event ID: 101');
+    ->expectsOutput('==> Sites queued for purging page cache.');
 });
 
 test('purge all sites object cache', function () {
     $this->clientMock->shouldReceive('request')->once()->with('GET', 'sites?page=1', [])->andReturn(
         new Response(200, [], listResponseJson([
-            ['id' => 1, 'domain' => 'hellfish.media', 'page_cache' => ['enabled' => true]],
-            ['id' => 2, 'domain' => 'staging.hellfish.media', 'page_cache' => ['enabled' => true]],
+            ['id' => 1, 'domain' => 'hellfish.media', 'page_cache' => ['enabled' => true], 'is_wordpress' => true],
+            ['id' => 2, 'domain' => 'staging.hellfish.media', 'page_cache' => ['enabled' => true], 'is_wordpress' => true],
         ]))
     );
 
@@ -66,6 +66,5 @@ test('purge all sites object cache', function () {
         ->andReturn(new Response(200, [], json_encode(['event_id' => 101])));
 
     $this->artisan('sites:purge --all --cache=object')
-        ->expectsOutput('Purging object cache for site hellfish.media. Event ID: 100')
-        ->expectsOutput('Purging object cache for site staging.hellfish.media. Event ID: 101');
+        ->expectsOutput('==> Sites queued for purging object cache.');
 });


### PR DESCRIPTION
Resolves #29 

## Description
We now pre-filter the sites by cache type enabled. Also, we use `queueResources` method to make the output consistent with other commands.

## Visuals
![image](https://user-images.githubusercontent.com/7433870/154531757-6c1bb4dd-5c5a-4c25-bb46-36076701bcfe.png)

## Testing Instructions
1. Make sure to have some Non-WordPress sites and some others with page cache disabled.
2. Run `spinupwp sites:purge --cache=object` only WP sites should be listed
3. Run `spinupwp sites:purge --cache=page` only sites with page cache enabled should be listed
4. Output should be consistent with other commands.

## Related Documentation
N/A

## Pre-review Checklist
- [x] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Feature/Unit tests have been added and/or updated (where appropriate).
- [x] Self-review of code changes has been completed.
- [N/A] Self-review of UI and UX changes has been completed, including dark mode and mobile responsiveness.
    - [N/A] UI matches the provided Figma mockups (when available).
- [x] Modified and surrounding functionality has been tested. Considerations have been made for both new and existing servers and sites.