### PR TITLE
Adds new search command for sites and servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ To get started, require the package globally via [Composer](https://getcomposer.
 
     composer global require spinupwp/spinupwp-cli
 
-In addition, you should make sure the `/vendor/bin` directory in your global Composer home directory is in your system's "PATH". Depending on your operating system this could be either `~/.composer/` or `~/.config/composer/`. You can use the `composer config --global home` command to check this location.
+In addition, you should make sure the `/vendor/bin` directory in your global Composer home directory is in your system's "PATH". Depending on your operating system this could
+be either `~/.composer/` or `~/.config/composer/`. You can use the `composer config --global home` command to check this location.
 
 ## Usage
 
@@ -45,6 +46,11 @@ If no profile is supplied, your default profile will be used (if configured).
 
     # List all servers
     spinupwp servers:list --fields=id,name,ip_address,ubuntu_version,database.server
+
+    # Search all servers
+    spinupwp servers:search <ip_address>
+    spinupwp servers:search <server_name>
+    spinupwp servers:search <server_id>
 
     # Reboot a server
     spinupwp servers:reboot <server_id>
@@ -95,6 +101,11 @@ Nested properties should use dot notation, for example, `database.server`.
     # List all sites
     spinupwp sites:list --fields=id,server_id,domain,site_user,php_version,page_cache,https
 
+    # Search all sites
+    spinupwp sites:search domain.com
+    spinupwp sites:search <site_user>
+    spinupwp sites:search <site_id>
+
     # Purge the page cache for a site
     spinupwp sites:purge <site_id> --cache=page
 
@@ -112,7 +123,6 @@ Nested properties should use dot notation, for example, `database.server`.
 
 You can pass any properties of the [Site Schema](https://api.spinupwp.com/?shell#tocS_Site) to the `--fields` flag.
 Nested properties should use dot notation, for example, `backups.next_run_time` or `git.branch`.
-
 
     # Create a site using field flags instead of interactive prompts
     spinupwp sites:create <server_id> --installation-method="<installation_method>" \

--- a/app/Commands/Concerns/SpecifyFields.php
+++ b/app/Commands/Concerns/SpecifyFields.php
@@ -29,7 +29,7 @@ trait SpecifyFields
         $this->applyFilter($fieldsFilter);
 
         collect($this->fieldsMap)->each(function (Field $field) use ($resource, &$fields) {
-            $label = $field->getDisplayLabel($this->displayFormat() === 'table');
+            $label = $field->getDisplayLabel($this->shouldShowNiceLabel());
 
             if (!property_exists($resource, $field->getName())) {
                 return;
@@ -73,7 +73,7 @@ trait SpecifyFields
     protected function applyFilter(?array $fieldsFilter): void
     {
         if (!empty($fieldsFilter)) {
-            $this->fieldsMap = array_filter($this->fieldsMap, fn (Field $field) => $field->isInFilter($fieldsFilter));
+            $this->fieldsMap = array_filter($this->fieldsMap, fn(Field $field) => $field->isInFilter($fieldsFilter));
         }
     }
 
@@ -81,6 +81,11 @@ trait SpecifyFields
     {
         $commandOptions = $this->config->getCommandConfiguration($this->name, $this->profile());
         return $this->option('fields') || (isset($commandOptions['fields']) && !empty($commandOptions['fields']));
+    }
+
+    protected function shouldShowNiceLabel(): bool
+    {
+        return in_array($this->displayFormat(), ['table', 'list']);
     }
 
     private function getCommandFieldsConfiguration(string $command, string $profile): ?array

--- a/app/Commands/Servers/SearchCommand.php
+++ b/app/Commands/Servers/SearchCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Commands\Servers;
+
+use App\Commands\Servers\Servers;
+use Illuminate\Support\Str;
+
+class SearchCommand extends Servers
+{
+    public string|null $keyword;
+
+    protected $signature = 'servers:search
+                            {keyword? : Your search term}
+                            {--fields= : The fields to output}
+                            {--format= : The output format (json or table)}
+                            {--profile= : The SpinupWP configuration profile to use}';
+
+    protected $description = 'List all servers';
+
+    protected function action(): int
+    {
+        $this->keyword = $this->argument('keyword');
+
+        $servers = collect($this->spinupwp->listServers());
+
+        if ($servers->isEmpty()) {
+            $this->warn('No servers found.');
+            return self::SUCCESS;
+        }
+
+        $servers->transform(fn($server) => $this->specifyFields($server, [
+            'id',
+            'name',
+            'ip_address',
+            'ubuntu_version',
+            'database.server',
+        ]));
+
+        if ($this->displayFormat() !== 'table') {
+            $this->info("Format not supported");
+            return self::FAILURE;
+        }
+
+        $this->promptForSearch($servers);
+
+        return self::SUCCESS;
+    }
+
+    protected function promptForSearch($servers)
+    {
+        if (!$this->keyword) {
+            $this->keyword = $this->ask('Enter a search term');
+        }
+
+        while (true) {
+            $filteredServers = $servers->filter(function ($server) {
+                return Str::contains($server['Name'], $this->keyword, true) ||
+                    Str::contains($server['IP Address'], $this->keyword, true);
+            })->values();
+
+            if ($filteredServers->isEmpty()) {
+                $this->info('No matching servers found.');
+                $this->keyword = $this->ask('Enter a search term');
+                continue;
+            }
+
+            $this->info("Matching servers:");
+
+            $filteredServers->each(function ($server, $key) {
+                $this->line(sprintf("%d: %s (%s)", $key + 1, $server['Name'], $server['IP Address']));
+            });
+
+            if ($filteredServers->count() > 1) {
+                $selection = $this->ask('Enter the number of the server to view');
+
+                if ($selection === '') {
+                    $this->keyword = null;
+                    continue;
+                }
+
+                if (is_numeric($selection) && $selection > 0 && $selection <= $filteredServers->count()) {
+                    $selectedServer = $filteredServers[$selection - 1];
+                    $this->format(collect([$selectedServer]));
+
+                    if ($this->confirm('Do you want to SSH into this server?')) {
+                        $this->call('servers:ssh', ['server_id' => $selectedServer['ID']]);
+                    }
+
+                    break;
+                }
+            }
+
+            if ($filteredServers->count() === 1) {
+                $selectedServer = $filteredServers[0];
+                $this->format(collect([$selectedServer]));
+
+                if ($this->confirm('Do you want to SSH into this server?')) {
+                    $this->call('servers:ssh', ['server_id' => $selectedServer['ID']]);
+                }
+
+                break;
+            }
+
+            $this->error('Invalid selection. Please try again.');
+        }
+    }
+}

--- a/app/Commands/Servers/SearchCommand.php
+++ b/app/Commands/Servers/SearchCommand.php
@@ -32,7 +32,7 @@ class SearchCommand extends Servers
         }
 
         $servers->transform(
-            fn($server) => $this->specifyFields($server, [
+            fn ($server) => $this->specifyFields($server, [
                 'id',
                 'name',
                 'ip_address',
@@ -40,7 +40,7 @@ class SearchCommand extends Servers
                 'database.server',
             ]));
 
-        if (!in_array($this->displayFormat(), self::SUPPORTED_FORMATS)) {
+        if (! in_array($this->displayFormat(), self::SUPPORTED_FORMATS)) {
             $this->info("Format not supported");
             return self::FAILURE;
         }
@@ -52,7 +52,7 @@ class SearchCommand extends Servers
 
     protected function promptForSearch(Collection $servers): void
     {
-        if (!$this->keyword) {
+        if (! $this->keyword) {
             $this->keyword = $this->ask('Enter a search term');
         }
 
@@ -108,7 +108,8 @@ class SearchCommand extends Servers
     {
         return $servers->filter(function ($server) {
             return Str::contains($server['Name'], $this->keyword, true) ||
-                Str::contains($server['IP Address'], $this->keyword, true);
+                Str::contains($server['IP Address'], $this->keyword, true) ||
+                Str::contains($server['Server ID'], $this->keyword, true);
         })->values()->map(function ($site, $index) {
             return array_merge(['Match' => $index + 1], $site);
         });

--- a/app/Commands/Servers/Servers.php
+++ b/app/Commands/Servers/Servers.php
@@ -13,7 +13,7 @@ abstract class Servers extends BaseCommand
     protected function setup(): void
     {
         $this->fieldsMap = [
-            (new Field('ID', 'id')),
+            (new Field('Server ID', 'id')),
             (new Field('Name', 'name')),
             (new Field('Provider Name', 'provider_name')),
             (new Field('IP Address', 'ip_address')),

--- a/app/Commands/Sites/SearchCommand.php
+++ b/app/Commands/Sites/SearchCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Commands\Sites;
+
+use App\Commands\Sites\Sites;
+use Illuminate\Support\Str;
+
+class SearchCommand extends Sites
+{
+    public string|null $keyword;
+
+    protected $signature = 'sites:search
+                            {keyword? : Your search term}
+                            {server_id? : Only list sites belonging to this server}
+                            {--fields= : The fields to output}
+                            {--format= : The output format (json or table)}
+                            {--profile= : The SpinupWP configuration profile to use}';
+
+    protected $description = 'Retrieves a list of sites';
+
+    protected function action(): int
+    {
+        $this->keyword = $this->argument('keyword');
+
+        $serverId = $this->argument('server_id');
+
+        if ($serverId) {
+            $sites = $this->spinupwp->listSites((int) $serverId);
+        } else {
+            $sites = $this->spinupwp->listSites();
+        }
+
+        if ($sites->isEmpty()) {
+            $this->warn('No sites found.');
+            return self::SUCCESS;
+        }
+
+        $sites->transform(
+            fn($site) => $this->specifyFields($site, [
+                'id',
+                'server_id',
+                'domain',
+                'site_user',
+                'php_version',
+                'page_cache',
+                'https',
+            ])
+        );
+
+        if ($this->displayFormat() !== 'table') {
+            $this->info("Format not supported");
+            return self::FAILURE;
+        }
+
+        $this->promptForSearch($sites);
+
+        return self::SUCCESS;
+    }
+
+    protected function promptForSearch($sites)
+    {
+        while (true) {
+            if (!$this->keyword) {
+                $this->keyword = $this->ask('Enter a search term');
+            }
+
+            $filteredSites = $sites->filter(function ($site) {
+                return Str::contains($site['Domain'], $this->keyword, true) || Str::contains($site['Site User'], $this->keyword, true);
+            })->values();
+
+            if ($filteredSites->isEmpty()) {
+                $this->info('No matching sites found.');
+                $this->keyword = $this->ask('Enter a search term');
+                continue;
+            }
+
+            $this->info("Matching sites:");
+
+            $filteredSites->each(function ($site, $key) {
+                $this->line(sprintf("%d: %s (%s)", $key + 1, $site['Domain'], $site['Site User']));
+            });
+
+            if ($filteredSites->count() > 1) {
+                $selection = $this->ask('Enter the number of the site to view');
+
+                if ($selection === '') {
+                    $this->keyword = null;
+                    continue;
+                }
+
+                if (is_numeric($selection) && $selection > 0 && $selection <= $filteredSites->count()) {
+                    $selectedSite = $filteredSites[$selection - 1];
+
+                    $this->format(collect([$selectedSite]));
+
+                    if ($this->confirm('Do you want to SSH into this site?')) {
+                        $this->call('site:ssh', ['site_id' => $selectedSite['ID']]);
+                    }
+
+                    break;
+                }
+            }
+
+            if ($filteredSites->count() === 1) {
+                $selectedSite = $filteredSites[0];
+                $this->format(collect([$selectedSite]));
+
+                if ($this->confirm('Do you want to SSH into this site?')) {
+                    $this->call('sites:ssh', ['site_id' => $selectedSite['ID']]);
+                }
+
+                break;
+            }
+
+
+            $this->error('Invalid selection. Please try again.');
+        }
+    }
+}

--- a/app/Commands/Sites/SearchCommand.php
+++ b/app/Commands/Sites/SearchCommand.php
@@ -118,7 +118,8 @@ class SearchCommand extends Sites
     {
         return $sites->filter(function ($site) {
             return Str::contains($site['Domain'], $this->keyword, true) ||
-                Str::contains($site['Site User'], $this->keyword, true);
+                Str::contains($site['Site User'], $this->keyword, true) ||
+                Str::contains($site['Site ID'], $this->keyword, true);
         })->values()->map(function ($site, $index) {
             return array_merge(['Match' => $index + 1], $site);
         });

--- a/app/Commands/Sites/Sites.php
+++ b/app/Commands/Sites/Sites.php
@@ -13,7 +13,8 @@ abstract class Sites extends BaseCommand
     protected function setUp(): void
     {
         $this->fieldsMap = [
-            (new Field('ID', 'id')),
+//            (new Field('ID', 'id')),
+            (new Field('Site ID', 'id')),
             (new Field('Server ID', 'server_id')),
             (new Field('Domain', 'domain')),
             (new Field('Additional Domains', 'additional_domains'))

--- a/tests/Feature/Commands/ServerSearchCommandTest.php
+++ b/tests/Feature/Commands/ServerSearchCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+$response = [
+    [
+        'id'             => 1,
+        'name'           => 'hellfish-media',
+        'provider_name'  => 'DigitalOcean',
+        'ubuntu_version' => '20.04',
+        'ip_address'     => '127.0.0.1',
+        'disk_space'     => [
+            'total'      => 25210576000,
+            'available'  => 17549436000,
+            'used'       => 7661140000,
+            'updated_at' => '2021-11-03T16:52:48.000000Z',
+        ],
+        'database'       => [
+            'server' => 'mysql-8.0',
+        ],
+    ],
+    [
+        'id'             => 2,
+        'name'           => 'staging.hellfish-media',
+        'provider_name'  => 'DigitalOcean',
+        'ubuntu_version' => '20.04',
+        'ip_address'     => '127.0.0.1',
+        'disk_space'     => [
+            'total'      => 25210576000,
+            'available'  => 17549436000,
+            'used'       => 7661140000,
+            'updated_at' => '2021-11-03T16:52:48.000000Z',
+        ],
+        'database'       => [
+            'server' => 'mysql-8.0',
+        ],
+    ],
+];
+beforeEach(function () use ($response) {
+    setTestConfigFile();
+});
+
+afterEach(function () {
+    deleteTestConfigFile();
+});
+
+it('list command with no api token configured', function () {
+    $this->spinupwp->setApiKey('');
+    $this->artisan('servers:search --profile=johndoe')
+        ->assertExitCode(1);
+});
+
+test('sites search does not support json formatting', function () use ($response) {
+    $this->clientMock->shouldReceive('request')->with('GET', 'servers?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson($response))
+    );
+    $this->artisan('servers:search --format json')->expectsOutput('Format not supported');
+});
+
+test('empty server search', function () {
+    $this->clientMock->shouldReceive('request')->with('GET', 'servers?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson([]))
+    );
+    $this->artisan('servers:search')->expectsOutput('No servers found.');
+});
+
+
+test('search prompts for term and server selection', function () use ($response) {
+    $this->clientMock->shouldReceive('request')->with('GET', 'servers?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson($response))
+    );
+
+    $this->artisan('servers:search --format table')
+        ->expectsQuestion('Enter a search term', 'hellfish-media')
+        ->expectsQuestion('Enter the number of the server to view', 1)
+        ->expectsConfirmation('Do you want to SSH into: hellfish-media (127.0.0.1)', 'yes');
+});

--- a/tests/Feature/Commands/ServersGetCommandTest.php
+++ b/tests/Feature/Commands/ServersGetCommandTest.php
@@ -58,7 +58,7 @@ test('servers table get command', function () use ($response) {
         new Response(200, [], json_encode(['data' => $response]))
     );
     $this->artisan('servers:get 1 --format=table')->expectsTable([], [
-        ['ID', '1'],
+        ['Server ID', '1'],
         ['Name', 'hellfish-media'],
         ['IP Address', '127.0.0.1'],
         ['Ubuntu', '20.04'],
@@ -73,7 +73,7 @@ test('servers table get specified columns and asks to save it in the config', fu
     $this->artisan('servers:get 1 --format=table --fields=id,name,ip_address')
         ->expectsConfirmation('Do you want to save the specified fields as the default for this command?', 'yes')
         ->expectsTable([], [
-            ['ID', '1'],
+            ['Server ID', '1'],
             ['Name', 'hellfish-media'],
             ['IP Address', '127.0.0.1'],
         ]);
@@ -88,7 +88,7 @@ test('servers table get only columns saved in the config', function () use ($res
 
     $this->artisan('servers:get 1 --format=table')
         ->expectsTable([], [
-            ['ID', '1'],
+            ['Server ID', '1'],
             ['Name', 'hellfish-media'],
         ]);
 

--- a/tests/Feature/Commands/ServersListCommandTest.php
+++ b/tests/Feature/Commands/ServersListCommandTest.php
@@ -64,7 +64,7 @@ test('servers table list command', function () use ($response) {
         new Response(200, [], listResponseJson($response))
     );
     $this->artisan('servers:list --format table')->expectsTable(
-        ['ID', 'Name', 'IP Address', 'Ubuntu', 'Database Server'],
+        ['Server ID', 'Name', 'IP Address', 'Ubuntu', 'Database Server'],
         [
             [
                 '1',
@@ -89,7 +89,7 @@ test('servers table list with specified columns command and asks to save it in t
         new Response(200, [], listResponseJson($response))
     );
     $this->artisan('servers:list --format=table --fields=id,name,ip_address')->expectsConfirmation('Do you want to save the specified fields as the default for this command?', 'yes')->expectsTable(
-        ['ID', 'Name', 'IP Address'],
+        ['Server ID', 'Name', 'IP Address'],
         [
             [
                 '1',
@@ -115,7 +115,7 @@ test('servers table list only columns saved in the config', function () use ($re
     resolve(Configuration::class)->setCommandConfiguration('servers:list', 'fields', 'id,name');
 
     $this->artisan('servers:list --format=table')->expectsTable(
-        ['ID', 'Name'],
+        ['Server ID', 'Name'],
         [
             [
                 '1',

--- a/tests/Feature/Commands/SitesGetCommandTest.php
+++ b/tests/Feature/Commands/SitesGetCommandTest.php
@@ -89,7 +89,7 @@ test('sites table get command', function () use ($response) {
         new Response(200, [], json_encode(['data' => $response]))
     );
     $this->artisan('sites:get 1 --format=table')->expectsTable([], [
-        ['ID', '1'],
+        ['Site ID', '1'],
         ['Server ID', '1'],
         ['Domain', 'hellfish.media'],
         ['Site User', 'hellfishmedia'],
@@ -131,7 +131,7 @@ test('site table get only columns saved in the config', function () use ($respon
 
     $this->artisan('sites:get 1 --format=table')
         ->expectsTable([], [
-            ['ID', '1'],
+            ['Site ID', '1'],
             ['Domain', 'hellfish.media'],
         ]);
 

--- a/tests/Feature/Commands/SitesListCommandTest.php
+++ b/tests/Feature/Commands/SitesListCommandTest.php
@@ -57,7 +57,7 @@ test('sites table list command', function () use ($response) {
         new Response(200, [], listResponseJson($response))
     );
     $this->artisan('sites:list --format table')->expectsTable(
-        ['ID', 'Server ID', 'Domain', 'Site User', 'PHP Version', 'Page Cache', 'HTTPS'],
+        ['Site ID', 'Server ID', 'Domain', 'Site User', 'PHP Version', 'Page Cache', 'HTTPS'],
         [
             [
                 1,
@@ -88,7 +88,7 @@ test('sites table list with specified columns command and asks to save it in the
     $this->artisan('sites:list --format table --fields=id,domain,site_user')
         ->expectsConfirmation('Do you want to save the specified fields as the default for this command?', 'yes')
         ->expectsTable(
-            ['ID', 'Domain', 'Site User'],
+            ['Site ID', 'Domain', 'Site User'],
             [
             [
                 1,
@@ -114,7 +114,7 @@ test('sites list only columns saved in the config', function () use ($response) 
     resolve(Configuration::class)->setCommandConfiguration('sites:list', 'fields', 'id,domain');
 
     $this->artisan('sites:list --format=table')->expectsTable(
-        ['ID', 'Domain'],
+        ['Site ID', 'Domain'],
         [
             [
                 1,

--- a/tests/Feature/Commands/SitesSearchCommandTest.php
+++ b/tests/Feature/Commands/SitesSearchCommandTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use App\Repositories\ConfigRepository as Configuration;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Facades\Artisan;
-use PHPUnit\Framework\ExpectationFailedException;
 
 $response = [
     [
@@ -62,7 +59,7 @@ test('empty sites search', function () {
 });
 
 
-test('sites search prompts for search term', function () use ($response) {
+test('search prompts for term and site selection', function () use ($response) {
     $this->clientMock->shouldReceive('request')->with('GET', 'sites?page=1&limit=100', [])->andReturn(
         new Response(200, [], listResponseJson($response))
     );
@@ -70,22 +67,5 @@ test('sites search prompts for search term', function () use ($response) {
     $this->artisan('sites:search --format table')
         ->expectsQuestion('Enter a search term', 'hellfish')
         ->expectsQuestion('Enter the number of the site to view', 1)
-        ->expectsTable(
-            ['ID', 'Server ID', 'Domain', 'Site User', 'PHP Version', 'Page Cache', 'HTTPS'],
-            [
-                [
-                    1,
-                    1,
-                    'hellfishmedia.com',
-                    'hellfish',
-                    '8.0',
-                    'Enabled',
-                    'Enabled',
-                ]
-            ]
-        )
-        ->expectsConfirmation('Do you want to SSH into hellfishmedia.com (hellfish)', 'yes')
-        // It's possible that since we're running another command, that we accept this one as working and relly on sites:ssh tests to pass.
-        ->expectsOutput('Establishing a secure connection to [hellfishmedia] as [hellfish]...')
-        ->assertExitCode(0);
+        ->expectsConfirmation('Do you want to SSH into: hellfishmedia.com (hellfish)', 'yes');
 });

--- a/tests/Feature/Commands/SitesSearchCommandTest.php
+++ b/tests/Feature/Commands/SitesSearchCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Repositories\ConfigRepository as Configuration;
+use App\Repositories\SpinupWpRepository;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Artisan;
+use LaravelZero\Framework\Kernel;
+use PHPUnit\Framework\ExpectationFailedException;
+
+$response = [
+    [
+        'id'          => 1,
+        'server_id'   => 1,
+        'domain'      => 'hellfishmedia.com',
+        'site_user'   => 'hellfish',
+        'php_version' => '8.0',
+        'page_cache'  => [
+            'enabled' => true,
+        ],
+        'https'       => [
+            'enabled' => true,
+        ],
+    ],
+    [
+        'id'          => 2,
+        'server_id'   => 2,
+        'domain'      => 'staging.hellfishmedia.com',
+        'site_user'   => 'staging-hellfish',
+        'php_version' => '8.0',
+        'page_cache'  => [
+            'enabled' => false,
+        ],
+        'https'       => [
+            'enabled' => false,
+        ],
+    ],
+];
+beforeEach(function () use ($response) {
+    setTestConfigFile();
+});
+
+afterEach(function () {
+    deleteTestConfigFile();
+});
+
+it('list command with no api token configured', function () {
+    $this->spinupwp->setApiKey('');
+    $this->artisan('sites:search --profile=johndoe')
+        ->assertExitCode(1);
+});
+
+test('sites search does not support json formatting', function () use ($response) {
+    $this->clientMock->shouldReceive('request')->with('GET', 'sites?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson($response))
+    );
+    $this->artisan('sites:search --format json')->expectsOutput('Format not supported');
+});
+
+test('empty sites search', function () {
+    $this->clientMock->shouldReceive('request')->with('GET', 'sites?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson([]))
+    );
+    $this->artisan('sites:search')->expectsOutput('No sites found.');
+});
+
+
+test('sites search prompts for search term', function () use ($response) {
+    $this->clientMock->shouldReceive('request')->with('GET', 'sites?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson($response))
+    );
+
+    $result = $this->artisan('sites:search --format table')
+        ->expectsQuestion('Enter a search term', 'hellfish')
+        ->expectsQuestion('Enter the number of the site to view', 1)
+        ->expectsTable(
+            ['ID', 'Server ID', 'Domain', 'Site User', 'PHP Version', 'Page Cache', 'HTTPS'],
+            [
+                [
+                    1,
+                    1,
+                    'hellfishmedia.com',
+                    'hellfish',
+                    '8.0',
+                    'Enabled',
+                    'Enabled',
+                ]
+            ]
+        )
+        ->expectsConfirmation('Do you want to SSH into this site?', 'yes')
+
+        // It's possible that since we're running another command, that we accept this one as working and relly on sites:ssh tests to pass.
+        ->expectsOutput('Establishing a secure connection to [hellfishmedia] as [hellfish]...')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/Commands/SitesSearchCommandTest.php
+++ b/tests/Feature/Commands/SitesSearchCommandTest.php
@@ -1,10 +1,8 @@
 <?php
 
 use App\Repositories\ConfigRepository as Configuration;
-use App\Repositories\SpinupWpRepository;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Artisan;
-use LaravelZero\Framework\Kernel;
 use PHPUnit\Framework\ExpectationFailedException;
 
 $response = [
@@ -69,7 +67,7 @@ test('sites search prompts for search term', function () use ($response) {
         new Response(200, [], listResponseJson($response))
     );
 
-    $result = $this->artisan('sites:search --format table')
+    $this->artisan('sites:search --format table')
         ->expectsQuestion('Enter a search term', 'hellfish')
         ->expectsQuestion('Enter the number of the site to view', 1)
         ->expectsTable(
@@ -86,8 +84,7 @@ test('sites search prompts for search term', function () use ($response) {
                 ]
             ]
         )
-        ->expectsConfirmation('Do you want to SSH into this site?', 'yes')
-
+        ->expectsConfirmation('Do you want to SSH into hellfishmedia.com (hellfish)', 'yes')
         // It's possible that since we're running another command, that we accept this one as working and relly on sites:ssh tests to pass.
         ->expectsOutput('Establishing a secure connection to [hellfishmedia] as [hellfish]...')
         ->assertExitCode(0);


### PR DESCRIPTION
## Description

I use the SpinupWP CLI across 6 servers with about 60 sites, so I was constantly using 'php spinup site:list | grep whatever' to find information and then running another command to login to that server or site.

I've added two new commands to enable "search", the output defaults to a table and can also use a list.

You're prompted to make a selection, and then confirm if you'd like to log into that server or site.

When searching for servers, I'm looking for a string match against `Name`, `IP Address`, and `Server ID`.
When searching for sites, I'm looking for a string match against `Domain`, `Site User`, and `Site ID`.

I've changed the table heading `ID` for servers to `Server ID`, it made more sense in the context of my search command and it was already referenced in the documentation as Server ID.

In doing so, I've updated the existing tests so that the table formats will pass.


## Visuals

Quick login if there's a single result

```
php spinupwp server:search picard
Matching servers:
+-------+-----------+--------+---------------+--------+-----------------+
| Match | Server ID | Name   | IP Address    | Ubuntu | Database Server |
+-------+-----------+--------+---------------+--------+-----------------+
| 1     | 12345     | picard | 123.000.10.20 | 22.04  | mysql-8.0       |
+-------+-----------+--------+---------------+--------+-----------------+

 Do you want to SSH into: picard (123.000.10.20) (yes/no) [no]:
 > 
```

Prompts again if there's no results.

```
php spinupwp server:search nothing
No matching servers found.

 Enter a search term:
 > picard

Matching servers:
+-------+-----------+--------+---------------+--------+-----------------+
| Match | Server ID | Name   | IP Address    | Ubuntu | Database Server |
+-------+-----------+--------+---------------+--------+-----------------+
| 1     | 12345     | picard | 123.000.10.20 | 22.04  | mysql-8.0       |
+-------+-----------+--------+---------------+--------+-----------------+

 Do you want to SSH into: picard (123.000.10.20) (yes/no) [no]:
 > 
```

Askes what match you'd like to login into if there are multiples.

```
php spinupwp site:search domain
Matching sites:
+-------+---------+-----------+----------------------------+----------------+-------------+------------+---------+
| Match | Site ID | Server ID | Domain                     | Site User      | PHP Version | Page Cache | HTTPS   |
+-------+---------+-----------+----------------------------+----------------+-------------+------------+---------+
| 1     | 123456  | 12345     | domain.ca                  | domain        | 8.2         | Enabled    | Enabled |
| 2     | 123456  | 12345     | staging.domain..com        | domainstagin  | 8.2         | Enabled    | Enabled |
+-------+---------+-----------+----------------------------+----------------+-------------+------------+---------+

 Enter the number of the site to view:
 > 2

 Do you want to SSH into: staging.domain..com (domainstagin) (yes/no) [no]:
 > 
```



## Testing Instructions

```
php spinupwp test
./vendor/bin/pest tests/Feature/Commands/SitesSearchCommandTest.php
./vendor/bin/pest tests/Feature/Commands/ServerSearchCommandTest.php
```



## Related Documentation
<!-- List any existing documentation links affected by this pull request. -->

- Added new [Server commands](https://github.com/adampatterson/spinupwp-cli/blob/main/README.md#servers)
- Added new [Site commands](https://github.com/adampatterson/spinupwp-cli/blob/main/README.md#sites)

## Pre-review Checklist
<!-- Complete these tasks prior to a review. -->

- [ ] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Feature/Unit tests have been added and/or updated (where appropriate).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UI and UX changes has been completed, including dark mode and mobile responsiveness.
    - [ ] UI matches the provided Figma mockups (when available).
- [x] Modified and surrounding functionality has been tested. Considerations have been made for both new and existing servers and sites.