### PR TITLE
Add ssh-key and servers/custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ If no profile is supplied, your default profile will be used (if configured).
     # Delete a server
     spinupwp servers:delete <server_id>
 
+    # Provision a custom server
+    spinupwp servers:create-custom
+
     # Get a server
     spinupwp servers:get <server_id> --fields=id,name,ip_address,ubuntu_version,database.server
 

--- a/app/Commands/Servers/CreateCustomCommand.php
+++ b/app/Commands/Servers/CreateCustomCommand.php
@@ -90,7 +90,7 @@ class CreateCustomCommand extends BaseCommand
                 ->withFlag('timezone')
                 ->withDefault('UTC'),
 
-            Ask::make('Post-Provision Script Path')
+            Ask::make('Post-Provision Script')
                 ->withFlag('post-provision-script'),
 
             Ask::make('Database Root Password')

--- a/app/Commands/Servers/CreateCustomCommand.php
+++ b/app/Commands/Servers/CreateCustomCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Commands\Servers;
+
+use App\Commands\BaseCommand;
+use App\Questions\Ask;
+use App\Questions\Choice;
+use App\Questions\HasQuestions;
+use App\Questions\Question;
+
+class CreateCustomCommand extends BaseCommand
+{
+    use HasQuestions;
+
+    public const UBUNTU_VERSIONS = ['24.04', '22.04'];
+
+    public const AUTH_METHODS = ['publickey', 'password'];
+
+    protected $signature = 'servers:create-custom
+                            {--provider-name= : Server provider name (e.g. OVH)}
+                            {--ubuntu-version= : Ubuntu version (must be one of the two latest LTS versions, e.g. 24.04)}
+                            {--ip-address= : Public IP address of the server}
+                            {--ssh-port= : SSH port (default: 22)}
+                            {--ssh-username= : SSH username}
+                            {--ssh-auth-method= : SSH authentication method (password or publickey)}
+                            {--ssh-password= : SSH password (if auth-method is password)}
+                            {--hostname= : Server hostname}
+                            {--timezone= : Server timezone (e.g. UTC, America/Toronto)}
+                            {--post-provision-script= : Path to a script to run as root after provisioning}
+                            {--database-root-password= : Root password for the database}
+                            {--database-provider-id= : ID of external database from SpinupWP settings}
+                            {--f|force : Run without prompting for confirmation}
+                            {--profile= : SpinupWP configuration profile to use}';
+
+    protected $description = 'Provision a custom server';
+
+    /**
+     * @var array<string, string|null>
+     */
+    protected array $userInput = [];
+
+    protected function action(): int
+    {
+        $this->userInput = $this->askQuestions($this->nonInteractive());
+
+        $server = $this->spinupwp->createCustomServer($this->userInput);
+
+        $this->displaySuccess(intval($server->eventId()));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Question[]
+     */
+    public function questions(): array
+    {
+        return [
+            Ask::make('Provider Name')
+                ->withFlag('provider-name'),
+
+            Choice::make('Ubuntu Version')
+                ->withFlag('ubuntu-version')
+                ->withChoices(self::UBUNTU_VERSIONS)
+                ->withDefault(self::UBUNTU_VERSIONS[0]),
+
+            Ask::make('IP Address')
+                ->withFlag('ip-address'),
+
+            Ask::make('SSH Port')
+                ->withFlag('ssh-port')
+                ->withDefault('22'),
+
+            Ask::make('SSH Username')
+                ->withFlag('ssh-username'),
+
+            Choice::make('SSH Authentication Method')
+                ->withFlag('ssh-auth-method')
+                ->withChoices(self::AUTH_METHODS)
+                ->withDefault(self::AUTH_METHODS[0]),
+
+            Ask::make('SSH Password')
+                ->withFlag('ssh-password')
+                ->unless(fn (array $answers): bool => $answers['ssh-auth-method'] === 'publickey'),
+
+            Ask::make('Hostname')
+                ->withFlag('hostname'),
+
+            Ask::make('Timezone')
+                ->withFlag('timezone')
+                ->withDefault('UTC'),
+
+            Ask::make('Post-Provision Script Path')
+                ->withFlag('post-provision-script'),
+
+            Ask::make('Database Root Password')
+                ->withFlag('database-root-password'),
+
+            Ask::make('Database Provider ID')
+                ->withFlag('database-provider-id'),
+        ];
+    }
+
+    protected function displaySuccess(int $eventId): void
+    {
+        $tableHeadings = [
+            'Event ID',
+            'Provider name',
+        ];
+
+        $tableRow = [
+            $eventId,
+            $this->userInput['provider-name'],
+        ];
+
+        $this->successfulStep('Server queued for creation.');
+
+        $this->stepTable($tableHeadings, [$tableRow]);
+    }
+}

--- a/app/Commands/SshKey/GetCommand.php
+++ b/app/Commands/SshKey/GetCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands\SshKey;
 
-use App\Commands\Sites\Sites;
+use App\Commands\BaseCommand;
 
-class GetCommand extends Sites
+class GetCommand extends BaseCommand
 {
     protected $signature = 'ssh-key:get
                             {--format= : The output format (json or table)}

--- a/app/Commands/SshKey/GetCommand.php
+++ b/app/Commands/SshKey/GetCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Commands\SshKey;
+
+use App\Commands\Sites\Sites;
+
+class GetCommand extends Sites
+{
+    protected $signature = 'ssh-key:get
+                            {--format= : The output format (json or table)}
+                            {--profile= : The SpinupWP configuration profile to use}';
+
+    protected $description = "Get SpinupWP's SSH Key";
+
+    public function action(): int
+    {
+        $this->largeOutput = true;
+        $key               = $this->spinupwp->getSshKey();
+
+        $this->format(['key' => $key]);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Questions/HasQuestions.php
+++ b/app/Questions/HasQuestions.php
@@ -14,7 +14,7 @@ trait HasQuestions
     {
         $answers = [];
         foreach ($this->questions() as $question) {
-            if ($question->skip) {
+            if (is_callable($question->skip) && call_user_func($question->skip, $answers)) {
                 continue;
             }
 

--- a/app/Questions/Question.php
+++ b/app/Questions/Question.php
@@ -2,6 +2,7 @@
 
 namespace App\Questions;
 
+use Closure;
 use Illuminate\Console\Concerns\InteractsWithIO;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
@@ -23,7 +24,7 @@ abstract class Question
 
     protected string $prompt = '';
 
-    public bool $skip = false;
+    public ?Closure $skip = null;
 
     final public function __construct(string $prompt)
     {
@@ -85,7 +86,7 @@ abstract class Question
 
     public function unless(callable $callback): self
     {
-        $this->skip = (bool) $callback();
+        $this->skip = $callback;
 
         return $this;
     }

--- a/app/Repositories/SpinupWpRepository.php
+++ b/app/Repositories/SpinupWpRepository.php
@@ -64,6 +64,11 @@ class SpinupWpRepository
         return $this->spinupwp->sites->get($siteId);
     }
 
+    public function getSshKey(): string
+    {
+        return $this->spinupwp->sshKeys->get();
+    }
+
     public function listSites(int $serverId = null): Collection
     {
         $params = [

--- a/app/Repositories/SpinupWpRepository.php
+++ b/app/Repositories/SpinupWpRepository.php
@@ -110,4 +110,25 @@ class SpinupWpRepository
 
         return $this->spinupwp->sites->create($serverId, $inputParams);
     }
+
+    /**
+     * @param array<string, string|null> $inputParams
+     */
+    public function createCustomServer(array $inputParams): ServerResource
+    {
+        return $this->spinupwp->servers->createCustom([
+            'provider_name'          => $inputParams['provider-name'],
+            'ubuntu_version'         => $inputParams['ubuntu-version'],
+            'ip_address'             => $inputParams['ip-address'],
+            'ssh_port'               => $inputParams['ssh-port'],
+            'username'               => $inputParams['ssh-username'],
+            'auth_method'            => $inputParams['ssh-auth-method'],
+            'password'               => $inputParams['ssh-password'] ?? null,
+            'hostname'               => $inputParams['hostname'],
+            'timezone'               => $inputParams['timezone'],
+            'post_provision_script'  => $inputParams['post-provision-script'],
+            'database_root_password' => $inputParams['database-root-password'],
+            'database_provider_id'   => $inputParams['database-provider-id'],
+        ]);
+    }
 }

--- a/config/commands.php
+++ b/config/commands.php
@@ -93,7 +93,7 @@ return [
     */
 
     'remove' => [
-        \LaravelZero\Framework\Commands\TestMakeCommand::class,
+        LaravelZero\Framework\Commands\TestMakeCommand::class,
     ],
 
 ];

--- a/tests/Feature/Commands/CustomServerCreateCommandTest.php
+++ b/tests/Feature/Commands/CustomServerCreateCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    setTestConfigFile();
+});
+
+test('"servers:create-custom" fails with invalid data', function () {
+    $params = [
+        'provider_name'          => 'test',
+        'ubuntu_version'         => 0,
+        'ip_address'             => null,
+        'ssh_port'               => '22',
+        'username'               => null,
+        'auth_method'            => 'publickey',
+        'password'               => null,
+        'hostname'               => null,
+        'timezone'               => 'UTC',
+        'post_provision_script'  => null,
+        'database_root_password' => null,
+        'database_provider_id'   => null,
+    ];
+
+    $this->clientMock->shouldReceive('request')->with('POST', 'servers/custom', [
+        'form_params' => $params,
+    ])->andReturn(
+        new Response(422, [], json_encode([
+            'message' => 'The given data was invalid.',
+            'errors'  => [
+                ['field' => 'error message'],
+            ],
+        ]))
+    );
+
+    $this->artisan('servers:create-custom --provider-name=test -f')
+        ->expectsOutput('Validation errors occurred.')
+        ->assertExitCode(1);
+});
+
+test('"servers:create-custom" succeeds with correct data', function () {
+    $params = [
+        'provider_name'            => 'my provider',
+          'ubuntu_version'         => '24.04',
+          'ip_address'             => '127.0.0.1',
+          'ssh_port'               => '22',
+          'username'               => 'root',
+          'auth_method'            => 'publickey',
+          'password'               => null,
+          'hostname'               => 'myserver.com',
+          'timezone'               => 'UTC',
+          'post_provision_script'  => null,
+          'database_root_password' => null,
+          'database_provider_id'   => null,
+    ];
+
+    $this->clientMock->shouldReceive('request')->with('POST', 'servers/custom', [
+        'form_params' => $params,
+    ])->andReturn(
+        new Response(200, [], json_encode([
+            'event_id' => '100',
+            'data'     => [
+                'id' => 1,
+            ],
+        ]))
+    );
+
+    $this->artisan('servers:create-custom
+                            --provider-name="my provider"
+                            --ubuntu-version=24.04
+                            --ip-address=127.0.0.1
+                            --ssh-port=22
+                            --ssh-username=root
+                            --ssh-auth-method=publickey
+                            --hostname=myserver.com -f')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/Commands/CustomServerCreateCommandTest.php
+++ b/tests/Feature/Commands/CustomServerCreateCommandTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
 test('"servers:create-custom" fails with invalid data', function () {
     $params = [
         'provider_name'          => 'test',
-        'ubuntu_version'         => 0,
+        'ubuntu_version'         => '24.04',
         'ip_address'             => null,
         'ssh_port'               => '22',
         'username'               => null,
@@ -20,7 +20,7 @@ test('"servers:create-custom" fails with invalid data', function () {
         'post_provision_script'  => null,
         'database_root_password' => null,
         'database_provider_id'   => null,
-    ];
+];
 
     $this->clientMock->shouldReceive('request')->with('POST', 'servers/custom', [
         'form_params' => $params,

--- a/tests/Feature/Commands/SshKeyGetCommandTest.php
+++ b/tests/Feature/Commands/SshKeyGetCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    setTestConfigFile();
+});
+
+afterEach(function () {
+    deleteTestConfigFile();
+});
+
+test('ssh key json get command', function () {
+    $this->clientMock->shouldReceive('request')->with('GET', 'ssh-key', [])->andReturn(
+        new Response(200, [], json_encode(['key' => 'ssh-rsa ...']))
+    );
+    $this->artisan('ssh-key:get')->expectsOutput(json_encode(['key' => 'ssh-rsa ...'], JSON_PRETTY_PRINT));
+});
+
+test('ssh key table get command', function () {
+    $this->clientMock->shouldReceive('request')->with('GET', 'ssh-key', [])->andReturn(
+        new Response(200, [], json_encode(['key' => 'ssh-rsa ...'], ))
+    );
+    $this->artisan('ssh-key:get --format=table')->expectsTable([], [
+        ['key', 'ssh-rsa ...'],
+    ]);
+});


### PR DESCRIPTION
## Description
<!-- Describe how and why changes were made. -->
**This PR depends on https://github.com/spinupwp/spinupwp-php-sdk/pull/31, hence we need to wait for it to be merged before testing and reviewing**
This adds support to our future `/ssh-key` and `/server/custom` endpoints.

## Testing Instructions
<!-- Help others test the pull request as efficiently as possible. -->

1. Install the package
1. Test out the new commands (ssh-key:get and servers:create-custom)