### PR TITLE
Add services:redis command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Nested properties should use dot notation, for example, `database.server`.
     # Restart PHP on all servers
     spinupwp services:php --all
 
+    # Restart Redis on a server
+    spinupwp services:redis <server_id>
+
+    # Restart Redis on all servers
+    spinupwp services:redis --all
+
 ### Sites
 
     # Create a site

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -4,6 +4,7 @@ namespace App\Commands\Concerns;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use SpinupWp\Resources\Resource;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -67,8 +68,12 @@ trait InteractsWithIO
      */
     protected function toJson($resource): void
     {
-        if (!is_array($resource)) {
+        if ($resource instanceof Resource) {
             $resource = $resource->toArray();
+        }
+
+        if ($resource instanceof Collection) {
+            $resource = $resource->map(fn ($item) => $item instanceof Resource ? $item->toArray() : $item);
         }
 
         $this->line((string) json_encode($resource, JSON_PRETTY_PRINT));

--- a/app/Commands/Concerns/SpecifyFields.php
+++ b/app/Commands/Concerns/SpecifyFields.php
@@ -31,7 +31,7 @@ trait SpecifyFields
         collect($this->fieldsMap)->each(function (Field $field) use ($resource, &$fields) {
             $label = $field->getDisplayLabel($this->displayFormat() === 'table');
 
-            if (!property_exists($resource, $field->getName())) {
+            if (!isset($resource->toArray()[$field->getName()])) {
                 return;
             }
 

--- a/app/Commands/Concerns/SpecifyFields.php
+++ b/app/Commands/Concerns/SpecifyFields.php
@@ -31,7 +31,7 @@ trait SpecifyFields
         collect($this->fieldsMap)->each(function (Field $field) use ($resource, &$fields) {
             $label = $field->getDisplayLabel($this->displayFormat() === 'table');
 
-            if (!isset($resource->toArray()[$field->getName()])) {
+            if (!isset($resource->{$field->getName()})) {
                 return;
             }
 

--- a/app/Commands/Services/RedisCommand.php
+++ b/app/Commands/Services/RedisCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Commands\Services;
+
+use App\Commands\BaseCommand;
+use App\Commands\Concerns\HasServerIdParameter;
+
+class RedisCommand extends BaseCommand
+{
+    use HasServerIdParameter;
+
+    protected $signature = 'services:redis
+                            {server_id? : The server to restart PHP on}
+                            {--all : Restart Redis on all servers}
+                            {--f|force : Restart Redis without prompting for confirmation}
+                            {--profile= : The SpinupWP configuration profile to use}';
+
+    protected $description = 'Restart Redis';
+
+    public function action(): int
+    {
+        if ($this->option('all') && $this->forceOrConfirm('Are you sure you want to restart Redis on all servers?')) {
+            $servers = $this->spinupwp->listServers();
+        } else {
+            $servers = $this->selectServer('restart Redis on');
+        }
+
+        $this->queueResources($servers, 'restartRedis', 'Redis restart');
+
+        return self::SUCCESS;
+    }
+}

--- a/config/commands.php
+++ b/config/commands.php
@@ -93,7 +93,7 @@ return [
     */
 
     'remove' => [
-        \LaravelZero\Framework\Commands\TestMakeCommand::class,
+        LaravelZero\Framework\Commands\TestMakeCommand::class,
     ],
 
 ];

--- a/tests/Feature/Commands/ServicesRedisCommandTest.php
+++ b/tests/Feature/Commands/ServicesRedisCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    setTestConfigFile();
+
+    $this->clientMock->shouldReceive('request')->with('GET', 'servers/1', [])->andReturn(
+        new Response(200, [], json_encode(['data' => ['id' => 1, 'name' => 'hellfish-media']]))
+    );
+
+    $this->clientMock->shouldReceive('request')->with('POST', 'servers/1/services/redis/restart', [])->andReturn(
+        new Response(200, [], json_encode(['event_id' => '100']))
+    );
+});
+
+afterEach(function () {
+    deleteTestConfigFile();
+});
+
+test('restart redis for a server', function () {
+    $this->artisan('services:redis 1')
+        ->expectsConfirmation('Are you sure you want to restart Redis on "hellfish-media"?', 'yes')
+        ->expectsOutput('==> Server queued for Redis restart.');
+});
+
+test('restart redis for a server with force option', function () {
+    $this->artisan('services:redis 1 --force')
+        ->expectsOutput('==> Server queued for Redis restart.');
+});
+
+test('restart redis on all servers', function () {
+    $this->clientMock->shouldReceive('request')->once()->with('GET', 'servers?page=1&limit=100', [])->andReturn(
+        new Response(200, [], listResponseJson([
+            ['id' => 1, 'name' => 'hellfish-media'],
+            ['id' => 2, 'name' => 'staging.hellfish-media'],
+        ]))
+    );
+    $this->clientMock->shouldReceive('request')->with('POST', 'servers/2/services/redis/restart', [])->andReturn(
+        new Response(200, [], json_encode(['event_id' => '101']))
+    );
+    $this->artisan('services:redis --all')
+        ->expectsConfirmation('Are you sure you want to restart Redis on all servers?', 'yes')
+        ->expectsOutput('==> Servers queued for Redis restart.');
+});


### PR DESCRIPTION
## Description
<!-- Describe how and why changes were made. -->
This PR adds a `services:redis` command to restart Redis on servers.


CI should pass once https://github.com/spinupwp/spinupwp-php-sdk/pull/34/files is merged.