### PR TITLE
Add sites:wp-cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Nested properties should use dot notation, for example, `database.server`.
     # Start an SSH session as the site user
     spinupwp sites:ssh <site_id>
 
+    # Run a WP-CLI command on a site
+    spinupwp sites:wp-cli <site_id> --command="core version"
+
+    # Run multiple WP-CLI commands on a site
+    spinupwp sites:wp-cli <site_id> --command="core version" --command="plugin list --status=active"
+
 You can pass any properties of the [Site Schema](https://api.spinupwp.com/?shell#tocS_Site) to the `--fields` flag.
 Nested properties should use dot notation, for example, `backups.next_run_time` or `git.branch`.
 

--- a/app/Commands/Sites/WpCliCommand.php
+++ b/app/Commands/Sites/WpCliCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Commands\Sites;
+
+use App\Commands\BaseCommand;
+
+class WpCliCommand extends BaseCommand
+{
+    protected $signature = 'sites:wp-cli
+                            {site_id? : The site to run WP-CLI commands on}
+                            {--command=* : The WP-CLI command(s) to run}
+                            {--profile= : The SpinupWP configuration profile to use}';
+
+    protected $description = 'Run WP-CLI commands on a site';
+
+    public function action(): int
+    {
+        $siteId = $this->argument('site_id');
+
+        if (empty($siteId)) {
+            $siteId = $this->askToSelectSite('Which site would you like to run WP-CLI commands on');
+        }
+
+        $commands = $this->option('command');
+
+        if (empty($commands)) {
+            $commands = $this->askForCommands();
+        }
+
+        if (empty($commands)) {
+            $this->warn('No commands provided.');
+            return self::SUCCESS;
+        }
+
+        $eventId = $this->spinupwp->sites->wpCli((int) $siteId, $commands);
+
+        $this->successfulStep('WP-CLI commands queued for execution.');
+
+        $this->streamOutput($eventId);
+
+        return self::SUCCESS;
+    }
+
+    protected function askForCommands(): array
+    {
+        $commands = [];
+
+        $this->step('Enter WP-CLI commands (empty line to finish):');
+
+        while (true) {
+            $command = $this->ask('Command');
+
+            if (empty($command)) {
+                break;
+            }
+
+            $commands[] = $command;
+        }
+
+        return $commands;
+    }
+
+    protected function streamOutput(int $eventId): void
+    {
+        $displayedLength = 0;
+
+        while (true) {
+            sleep(2);
+
+            $event = $this->spinupwp->events->get($eventId);
+            $output = $event->output ?? '';
+
+            if (strlen($output) > $displayedLength) {
+                $this->output->write(substr($output, $displayedLength));
+                $displayedLength = strlen($output);
+            }
+
+            if (in_array($event->status, ['deployed', 'failed'])) {
+                if ($event->status === 'failed') {
+                    $this->error('WP-CLI command execution failed.');
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/app/Commands/Sites/WpCliCommand.php
+++ b/app/Commands/Sites/WpCliCommand.php
@@ -76,10 +76,6 @@ class WpCliCommand extends BaseCommand
             }
 
             if (in_array($event->status, ['deployed', 'failed'])) {
-                if ($event->status === 'failed') {
-                    $this->error('WP-CLI command execution failed.');
-                }
-
                 break;
             }
         }

--- a/app/Commands/Sites/WpCliCommand.php
+++ b/app/Commands/Sites/WpCliCommand.php
@@ -67,7 +67,7 @@ class WpCliCommand extends BaseCommand
         while (true) {
             sleep(2);
 
-            $event = $this->spinupwp->events->get($eventId);
+            $event  = $this->spinupwp->events->get($eventId);
             $output = $event->output ?? '';
 
             if (strlen($output) > $displayedLength) {

--- a/tests/Feature/Commands/SitesWpCliCommandTest.php
+++ b/tests/Feature/Commands/SitesWpCliCommandTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    setTestConfigFile();
+
+    $this->clientMock->shouldReceive('request')->with('POST', 'sites/1/wp-cli', [
+        'form_params' => [
+            'commands' => ['core version'],
+        ],
+    ])->andReturn(
+        new Response(200, [], json_encode(['event_id' => 100]))
+    );
+});
+
+afterEach(function () {
+    deleteTestConfigFile();
+});
+
+test('wp-cli command with site ID and command supplied', function () {
+    $this->clientMock->shouldReceive('request')->with('GET', 'events/100', [])->andReturn(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id'     => 100,
+                'status' => 'deployed',
+                'output' => "$ core version\n6.4.2",
+            ],
+        ]))
+    );
+
+    $this->artisan('sites:wp-cli', ['site_id' => '1', '--command' => ['core version']])
+        ->expectsOutput('==> WP-CLI commands queued for execution.')
+        ->assertExitCode(0);
+});
+
+test('wp-cli command with interactive site selection', function () {
+    $this->clientMock->shouldReceive('request')->once()->with('GET', 'sites?page=1&limit=100', [])->andReturn(
+        new Response(200, [], json_encode([
+            'data' => [
+                [
+                    'id'     => 1,
+                    'domain' => 'hellfishmedia.com',
+                ],
+            ],
+            'pagination' => [
+                'previous' => null,
+                'next'     => null,
+                'count'    => 1,
+            ],
+        ]))
+    );
+
+    $this->clientMock->shouldReceive('request')->with('GET', 'events/100', [])->andReturn(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id'     => 100,
+                'status' => 'deployed',
+                'output' => "$ core version\n6.4.2",
+            ],
+        ]))
+    );
+
+    $this->artisan('sites:wp-cli', ['--command' => ['core version']])
+        ->expectsQuestion('Which site would you like to run WP-CLI commands on', '1')
+        ->expectsOutput('==> WP-CLI commands queued for execution.')
+        ->assertExitCode(0);
+});
+
+test('wp-cli command with multiple commands', function () {
+    $this->clientMock->shouldReceive('request')->with('POST', 'sites/1/wp-cli', [
+        'form_params' => [
+            'commands' => ['core version', 'plugin list --status=active'],
+        ],
+    ])->andReturn(
+        new Response(200, [], json_encode(['event_id' => 101]))
+    );
+
+    $this->clientMock->shouldReceive('request')->with('GET', 'events/101', [])->andReturn(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id'     => 101,
+                'status' => 'deployed',
+                'output' => "$ core version\n6.4.2\n\n$ plugin list --status=active\nName\tStatus\tVersion",
+            ],
+        ]))
+    );
+
+    $this->artisan('sites:wp-cli', ['site_id' => '1', '--command' => ['core version', 'plugin list --status=active']])
+        ->expectsOutput('==> WP-CLI commands queued for execution.')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
Adds a new `sites:wp-cli` command to run WP-CLI commands on a site from the CLI.

We can't merge this until we ship the new SDK version.